### PR TITLE
EndOfDay / Receipt for merchant

### DIFF
--- a/lib/Secucard.Connect/Product/Smart/Model/Transaction.cs
+++ b/lib/Secucard.Connect/Product/Smart/Model/Transaction.cs
@@ -65,6 +65,9 @@ namespace Secucard.Connect.Product.Smart.Model
         [DataMember(Name = "receipt", EmitDefaultValue = false)]
         public List<ReceiptLine> ReceiptLines { get; set; }
 
+        [DataMember(Name = "receipt_merchant", EmitDefaultValue = false)]
+        public List<ReceiptLine> ReceiptLinesMerchant { get; set; }
+
         [DataMember(Name = "receipt_number", EmitDefaultValue = false)]
         public string ReceiptNumber { get; set; }
 

--- a/lib/Secucard.Connect/Product/Smart/TransactionsService.cs
+++ b/lib/Secucard.Connect/Product/Smart/TransactionsService.cs
@@ -93,7 +93,17 @@
         /// <returns></returns>
         public Transaction EndOfDay()
         {
-            return Execute<Transaction>(null, "endOfDay", null, null, new ChannelOptions { Channel = ChannelOptions.ChannelStomp });
+            // For EndOfDay STOMP is required
+            var properties = Properties.GetDefault();
+
+            if (properties.Get("Stomp.Enabled", false))
+            {
+                return Execute<Transaction>(null, "endOfDay", null, null, new ChannelOptions { Channel = ChannelOptions.ChannelStomp });
+            }
+            else
+            {
+                throw new System.Exception("For EndOfDay Stomp has to be enabled");
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
- Smart transaction object has a new field receipt_merchant (Händlerbeleg)
- EndOfDay needs STOMP